### PR TITLE
remove unnecessary body from RestTemplate calls to plain old get requests per Bryan's suggestion

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/CollegeSubredditQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/CollegeSubredditQueryService.java
@@ -41,7 +41,7 @@ public class CollegeSubredditQueryService {
         headers.setAccept(List.of(MediaType.TEXT_PLAIN));
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
 
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class);
         String csvData =  re.getBody();

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/CountryCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/CountryCodeQueryService.java
@@ -38,7 +38,7 @@ public class CountryCodeQueryService {
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
 
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class);
         return re.getBody();

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/EarthquakeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/EarthquakeQueryService.java
@@ -38,7 +38,7 @@ public class EarthquakeQueryService {
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
 
         String ucsbLat = "34.4140"; // hard coded params for Storke Tower
         String ucsbLong = "-119.8489";


### PR DESCRIPTION
In this PR we remove unnecessary body param from RestTemplate calls to plain old get requests per Bryan's suggestion